### PR TITLE
SpellQueue More Optimizations

### DIFF
--- a/extensions/spell.lua
+++ b/extensions/spell.lua
@@ -31,6 +31,7 @@ function SpellListener:CONSOLE_MESSAGE(msg, color)
   local ability = string.match(msg, "queue %a+ (%a+)")
 
   if target and ability then
+    local slot = #queue + 1
     ability = Spell[ability]
 
     if not ability or ability.Slot < 0 or ability:CooldownRemaining() > Me:GCDCooldown() then
@@ -46,14 +47,14 @@ function SpellListener:CONSOLE_MESSAGE(msg, color)
     local spell = {
       target = target,
       ability = ability,
-      timer = wector.Game.Time + 3000
+      timer = wector.Game.Time + slot * 3000
     }
 
     for _, v in pairs(queue) do
       if v.ability == ability then return end
     end
 
-    table.insert(queue, spell)
+    queue[slot] = spell
     Alert("Queued: " .. ability.Name .. " on " .. target, 3)
   else
     print("Invalid Macro Expression")

--- a/extensions/spell.lua
+++ b/extensions/spell.lua
@@ -47,7 +47,7 @@ function SpellListener:CONSOLE_MESSAGE(msg, color)
     local spell = {
       target = target,
       ability = ability,
-      timer = wector.Game.Time + slot * 3000
+      timer = #queue == 0 and wector.Game.Time + 3000 or queue[#queue].timer + 3000
     }
 
     for _, v in pairs(queue) do


### PR DESCRIPTION
We want each spell to get 3 seconds of try-time
Currently it does 3 seconds for all, even if you push 10 spells into it, all will be **removed** in **3** seconds, which isn't good 😄 
